### PR TITLE
fix bug in cohesion force calculation of last node

### DIFF
--- a/src/differential_growth.rs
+++ b/src/differential_growth.rs
@@ -252,7 +252,7 @@ impl DifferentialGrowth {
             sum.add_assign(self.nodes[n - 1 - 1].position.coords);
             sum.add_assign(self.nodes[0].position.coords);
             sum.div_assign(2.0);
-            cohesion_forces.push(self.nodes[0].seek(&sum));
+            cohesion_forces.push(self.nodes[n - 1].seek(&sum));
         }
 
         return cohesion_forces;


### PR DESCRIPTION
This typo caused the last edge, between node 0 and node n-1, to never properly settle in equilibrium. Figured I'd contribute, and while I'm at it thank you for the very well put together project!